### PR TITLE
Add benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [14.x, 16.x, 18.x, 20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/ & https://fastify.dev/docs/latest/Reference/LTS/#schedule
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # fastify-plugin-ts
 
-This is an experimental rewrite of [fastify-plugin](https://github.com/fastify/fastify-plugin), written in Typescript.
+This is an experimental rewrite of [fastify-plugin](https://github.com/fastify/fastify-plugin), written in Typescript. Just to experiment if this plugin in TS has any performance penalty ([fastify-plugin #219](https://github.com/fastify/fastify-plugin/issues/219))
+
+## Installation
+
+```sh
+pnpm i fastify-plugin-ts
+```
+
+## Running benchmarks
+```sh
+pnpm benchmark
+```

--- a/benchmark/bench-worker.ts
+++ b/benchmark/bench-worker.ts
@@ -1,0 +1,154 @@
+// https://github.com/TypeStrong/ts-node#missing-types:~:text=Another%20option%20is%20triple%2Dslash%20directives
+//
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../typings/benchmark-async.d.ts" />
+
+import fp from 'fastify-plugin'
+import fpts from '../plugin'
+import Benchmark from 'benchmark-async'
+import fastify, { FastifyInstance } from 'fastify'
+
+import { workerData, parentPort, MessagePort } from 'worker_threads'
+import assert from 'assert'
+
+function throwIfParentPortIsNull (port: typeof parentPort | null): asserts port is MessagePort {
+  assert.ok(port !== null, 'this script needs to be run as a worker thread')
+}
+
+type FpOrFpTs = typeof fp | typeof fpts
+
+const numberOfPlugins = 10
+const suite = new Benchmark.Suite({
+  name: workerData.name,
+  minSamples: 100,
+  async: true,
+  delay: 0
+})
+
+let fastifyInstance: null | FastifyInstance = null
+
+function registerDependencies (fastifyInstance: FastifyInstance, fpLike: FpOrFpTs): PromiseLike<unknown> {
+  for (const dependencyName of (workerData.requiredDependencies as string[] | undefined) ?? []) {
+    void fastifyInstance.register(
+      fpLike(
+        (_fastify, _opts, next) => next(),
+        {
+          name: dependencyName
+        }
+      )
+    )
+  }
+
+  const promise = fastifyInstance.register(
+    (_fastify, _opts, next) => next()
+  )
+
+  return promise
+}
+
+function registerDecorators (fastifyInstance: FastifyInstance, fpLike: FpOrFpTs): void {
+  for (const decoratorName of (workerData.metadata.decorators?.fastify as string[] | undefined) ?? []) {
+    fastifyInstance.decorate(
+      decoratorName,
+      fpLike(
+        (_fastify, _opts, next) => next(),
+        {
+          name: decoratorName
+        }
+      )
+    )
+  }
+
+  for (const decoratorName of (workerData.metadata.decorators?.reply as string[] | undefined) ?? []) {
+    fastifyInstance.decorateReply(
+      decoratorName,
+      fpLike(
+        (_fastify, _opts, next) => next(),
+        {
+          name: decoratorName
+        }
+      )
+    )
+  }
+}
+
+function registerPlugins (fastifyInstance: FastifyInstance, fpLike: FpOrFpTs): void {
+  for (let i = 0; i < numberOfPlugins; i++) {
+    void fastifyInstance.register(
+      fpLike(
+        (_fastify, _opts, next) => next(),
+        workerData.metadata
+      )
+    )
+  }
+}
+
+function generateSetupFunction (fpLike: FpOrFpTs) {
+  return function fn (deferred: { suResolve: () => void }) {
+    fastifyInstance = fastify()
+
+    registerDecorators(fastifyInstance, fpLike)
+
+    void registerDependencies(fastifyInstance, fpLike).then(() => {
+      assert.ok(fastifyInstance !== null, 'fastify instance is not initialized')
+
+      registerPlugins(fastifyInstance, fpLike)
+      deferred.suResolve()
+    })
+  }
+}
+
+function functionToBench (deferred: { resolve: () => void }): void {
+  assert.ok(fastifyInstance !== null, 'fastify instance is not initialized')
+
+  void fastifyInstance.ready().then(() => {
+    deferred.resolve()
+  })
+}
+
+function benchmarkTeardown (deferred: { tdResolve: () => void }): void {
+  assert.ok(fastifyInstance !== null, 'fastify instance is not initialized')
+
+  fastifyInstance.close()
+    .then(() => {
+      deferred.tdResolve()
+    })
+    .catch((err) => { throw err })
+}
+
+suite
+  .add(
+    'Fastify Plugin',
+    {
+      setup: generateSetupFunction(fp),
+      fn: functionToBench,
+      teardown: benchmarkTeardown,
+      defer: true
+    }
+  )
+  .add(
+    'Fastify Plugin Typescript',
+    {
+      setup: generateSetupFunction(fpts),
+      fn: functionToBench,
+      teardown: benchmarkTeardown,
+      defer: true
+    }
+  )
+  .on('start', function () {
+    throwIfParentPortIsNull(parentPort)
+
+    parentPort.postMessage(`Benchmark for ${String(workerData.name)}`)
+  })
+  .on('cycle', function (event: Event) {
+    throwIfParentPortIsNull(parentPort)
+
+    parentPort.postMessage(String(event.target))
+  })
+  .on('complete', function () {
+    throwIfParentPortIsNull(parentPort)
+    const fastestSuite = suite.filter('fastest').shift()
+
+    parentPort.postMessage('Fastest is ' + String(fastestSuite.name))
+  })
+  .run()

--- a/benchmark/bench.ts
+++ b/benchmark/bench.ts
@@ -1,0 +1,73 @@
+import { Worker } from 'worker_threads'
+import path from 'path'
+import { PluginMetadata } from '../types'
+
+const BENCH_WORKER_PATH = path.join(__dirname, 'bench-worker.ts')
+
+interface BenchmarkCase {
+  name: string
+  requiredDependencies?: string[]
+  metadata: PluginMetadata
+}
+
+const benchmarkCases: BenchmarkCase[] = [
+  {
+    name: 'simple case',
+    metadata: {}
+  },
+  {
+    name: 'fastify version checking',
+    metadata: {
+      fastify: '4.x'
+    }
+  },
+  {
+    name: 'fastify dependencies checking',
+    requiredDependencies: ['plugin1-name', 'plugin2-name'],
+    metadata: {
+      dependencies: ['plugin1-name', 'plugin2-name']
+    }
+  },
+  {
+    name: 'fastify decorators checking',
+    metadata: {
+      decorators: {
+        fastify: ['plugin1', 'plugin2'],
+        reply: ['compress']
+      }
+    }
+  }
+]
+
+async function runBenchmark (benchmarkCase: BenchmarkCase): Promise<string> {
+  const worker = new Worker(BENCH_WORKER_PATH, { workerData: benchmarkCase })
+
+  return await new Promise((resolve, reject) => {
+    worker.on('error', reject)
+
+    let result = ''
+
+    worker.on('message', (msg: string) => {
+      result += msg + '\n'
+    })
+
+    worker.on('exit', (code) => {
+      if (code === 0) {
+        resolve(result)
+      } else {
+        reject(new Error(`Worker stopped with exit code ${code}`))
+      }
+    })
+  })
+}
+
+async function runBenchmarks (): Promise<void> {
+  for (const benchmarkCase of benchmarkCases) {
+    const result = await runBenchmark(benchmarkCase)
+    console.log(result)
+  }
+}
+
+runBenchmarks().catch((err) => {
+  console.log('An error has occured: ', err)
+})

--- a/benchmark/bench.ts
+++ b/benchmark/bench.ts
@@ -33,7 +33,8 @@ const benchmarkCases: BenchmarkCase[] = [
     metadata: {
       decorators: {
         fastify: ['plugin1', 'plugin2'],
-        reply: ['compress']
+        reply: ['compress'],
+        request: ['request-decorator']
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "ts-standard",
     "test": "tap --ts --no-check-coverage",
     "build": "tsc",
-    "prepublish": "npm run build && npm test"
+    "prepublish": "npm run build && npm test",
+    "benchmark": "node -r ts-node/register ./benchmark/bench.ts"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,7 @@
     "@types/proxyquire": "^1.3.28",
     "@types/tap": "^15.0.8",
     "fastify": "^4.0.1",
+    "fastify-plugin": "^4.5.1",
     "proxyquire": "^2.1.3",
     "tap": "^16.0.1",
     "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^20.1.0",
     "@types/proxyquire": "^1.3.28",
     "@types/tap": "^15.0.8",
+    "benchmark-async": "^2.2.0",
     "fastify": "^4.20.0",
     "fastify-plugin": "^4.5.1",
     "proxyquire": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^20.1.0",
     "@types/proxyquire": "^1.3.28",
     "@types/tap": "^15.0.8",
-    "fastify": "^4.0.1",
+    "fastify": "^4.20.0",
     "fastify-plugin": "^4.5.1",
     "proxyquire": "^2.1.3",
     "tap": "^16.0.1",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2022",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["ES2022"],
+    "lib": ["ES2020"],
     "moduleResolution": "node16",
     "rootDir": ".",
     "outDir": "dist",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "target": "es2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "moduleResolution": "node16",
+    "rootDir": ".",
+    "outDir": "dist",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "importHelpers": false,
+    "alwaysStrict": true,
+    "sourceMap": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strict": true,
+    "typeRoots" : ["./node_modules/@types", "./typings"]
+  },
+  "include": [
+    "./plugin.ts",
+    "./types.ts",
+    "./lib/**/*.ts",
+    "./benchmark/*.ts",
+    "./test/*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "declaration": true,
     "outDir": "dist",
-    "target": "es2022",
+    "target": "es2020",
     "module": "commonjs",
-    "lib": ["ES2022"],
+    "lib": ["ES2020"],
     "moduleResolution": "node16",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/typings/benchmark-async.d.ts
+++ b/typings/benchmark-async.d.ts
@@ -1,0 +1,208 @@
+declare module 'benchmark-async' {
+
+  class Benchmark {
+    static filter<T>(arr: T[], callback: (value: T) => any, thisArg?: any): T[]
+    static filter<T>(arr: T[], filter: string, thisArg?: any): T[]
+    static formatNumber (num: number): string
+    static join (obj: Object, separator1?: string, separator2?: string): string
+    static invoke (benches: Benchmark[], name: string | Object, ...args: any[]): any[]
+    static runInContext (context: Object): Function
+
+    static each (obj: Object | any[], callback: Function, thisArg?: any): void
+    static forEach<T>(arr: T[], callback: (value: T) => any, thisArg?: any): void
+    static forOwn (obj: Object, callback: Function, thisArg?: any): void
+    static has (obj: Object, path: any[] | string): boolean
+    static indexOf<T>(arr: T[], value: T, fromIndex?: number): number
+    static map<T, K>(arr: T[], callback: (value: T) => K, thisArg?: any): K[]
+    static reduce<T, K>(arr: T[], callback: (accumulator: K, value: T) => K, thisArg?: any): K
+
+    static options: Benchmark.Options
+    static platform: Benchmark.Platform
+    static support: Benchmark.Support
+    static version: string
+
+    constructor (fn: Function | string, options?: Benchmark.Options)
+    constructor (name: string, fn: Function | string, options?: Benchmark.Options)
+    constructor (name: string, options?: Benchmark.Options)
+    constructor (options: Benchmark.Options)
+
+    id: number
+    name?: string
+    count: number
+    cycles: number
+    hz: number
+    compiled: Function | string
+    error: Error
+    fn: Function | string
+    aborted: boolean
+    running: boolean
+    setup: Function | string
+    teardown: Function | string
+
+    stats: Benchmark.Stats
+    times: Benchmark.Times
+
+    abort (): Benchmark
+    clone (options: Benchmark.Options): Benchmark
+    compare (benchmark: Benchmark): number
+    emit (type: string | Object): any
+    listeners (type: string): Function[]
+    off (type?: string, listener?: Function): Benchmark
+    off (types: string[]): Benchmark
+    on (type?: string, listener?: Function): Benchmark
+    on (types: string[]): Benchmark
+    reset (): Benchmark
+    run (options?: Benchmark.Options): Benchmark
+    toString (): string
+  }
+
+  namespace Benchmark {
+    export interface Options {
+      async?: boolean | undefined
+      defer?: boolean | undefined
+      delay?: number | undefined
+      id?: string | undefined
+      initCount?: number | undefined
+      maxTime?: number | undefined
+      minSamples?: number | undefined
+      minTime?: number | undefined
+      name?: string | undefined
+      onAbort?: Function | undefined
+      onComplete?: Function | undefined
+      onCycle?: Function | undefined
+      onError?: Function | undefined
+      onReset?: Function | undefined
+      onStart?: Function | undefined
+      setup?: Function | string | undefined
+      teardown?: Function | string | undefined
+      fn?: Function | string | undefined
+      queued?: boolean | undefined
+    }
+
+    export interface Platform {
+      description: string
+      layout: string
+      product: string
+      name: string
+      manufacturer: string
+      os: string
+      prerelease: string
+      version: string
+      toString: () => string
+    }
+
+    export interface Support {
+      browser: boolean
+      timeout: boolean
+      decompilation: boolean
+    }
+
+    export interface Stats {
+      moe: number
+      rme: number
+      sem: number
+      deviation: number
+      mean: number
+      sample: any[]
+      variance: number
+    }
+
+    export interface Times {
+      cycle: number
+      elapsed: number
+      period: number
+      timeStamp: number
+    }
+
+    export class Deferred {
+      constructor (clone: Benchmark)
+
+      benchmark: Benchmark
+      cycles: number
+      elapsed: number
+      timeStamp: number
+
+      resolve (): void
+    }
+
+    export interface Target {
+      options: Options
+      async?: boolean | undefined
+      defer?: boolean | undefined
+      delay?: number | undefined
+      initCount?: number | undefined
+      maxTime?: number | undefined
+      minSamples?: number | undefined
+      minTime?: number | undefined
+      name?: string | undefined
+      fn?: Function | undefined
+      id: number
+      stats?: Stats | undefined
+      times?: Times | undefined
+      running: boolean
+      count?: number | undefined
+      compiled?: Function | undefined
+      cycles?: number | undefined
+      hz?: number | undefined
+    }
+
+    export class Event {
+      constructor (type: string | Object)
+
+      aborted: boolean
+      cancelled: boolean
+      currentTarget: Object
+      result: any
+      target: Target
+      timeStamp: number
+      type: string
+    }
+
+    export class Suite {
+      static options: { name: string }
+
+      constructor (name?: string, options?: Options)
+      constructor (options?: Options)
+
+      length: number
+      aborted: boolean
+      running: boolean
+      name?: string
+
+      abort (): Suite
+      add (name: string, fn: Function | string, options?: Options): Suite
+      add (fn: Function | string, options?: Options): Suite
+      add (name: string, options?: Options): Suite
+      add (options: Options): Suite
+      clone (options: Options): Suite
+      emit (type: string | Object): any
+      filter (callback: Function | string): Suite
+      join (separator?: string): string
+      listeners (type: string): Function[]
+      off (type?: string, callback?: Function): Suite
+      off (types: string[]): Suite
+      on (type?: string, callback?: Function): Suite
+      on (types: string[]): Suite
+      push (benchmark: Benchmark): number
+      reset (): Suite
+      run (options?: Options): Suite
+      reverse (): any[]
+      sort (compareFn: (a: any, b: any) => number): any[]
+      splice (start: number, deleteCount?: number): any[]
+      unshift (benchmark: Benchmark): number
+
+      each (callback: Function): Suite
+      forEach (callback: Function): Suite
+      indexOf (value: any): number
+      map (callback: Function | string): any[]
+      reduce<T>(callback: Function, accumulator: T): T
+
+      pop (): Suite
+      shift (): Benchmark
+      slice (start: number, end: number): any[]
+      slice (start: number, deleteCount: number, ...values: any[]): any[]
+    }
+  }
+
+  export = Benchmark
+}


### PR DESCRIPTION
This PR adds some benchmarks. Here are the results on my machine
```
Benchmark for simple case
Fastify Plugin x 98,947 ops/sec ±2.54% (79 runs sampled)
Fastify Plugin Typescript x 98,539 ops/sec ±1.91% (85 runs sampled)
Fastest is Fastify Plugin Typescript

Benchmark for fastify version checking
Fastify Plugin x 96,928 ops/sec ±2.53% (78 runs sampled)
Fastify Plugin Typescript x 97,231 ops/sec ±1.88% (82 runs sampled)
Fastest is Fastify Plugin Typescript

Benchmark for fastify dependencies checking
Fastify Plugin x 100,273 ops/sec ±1.89% (80 runs sampled)
Fastify Plugin Typescript x 99,840 ops/sec ±1.68% (83 runs sampled)
Fastest is Fastify Plugin

Benchmark for fastify decorators checking
Fastify Plugin x 98,176 ops/sec ±2.01% (80 runs sampled)
Fastify Plugin Typescript x 99,913 ops/sec ±1.75% (84 runs sampled)
Fastest is Fastify Plugin Typescript
```